### PR TITLE
improved efficiency of set_mask

### DIFF
--- a/satellitepy/data/utils.py
+++ b/satellitepy/data/utils.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+from satellitepy.data.cutout.geometry import BBox
 
 def set_mask(labels,mask_path,bbox_type):
     """
@@ -18,10 +19,11 @@ def set_mask(labels,mask_path,bbox_type):
     mask = cv2.cvtColor(cv2.imread(str(mask_path)), cv2.COLOR_RGB2GRAY)
     empty_mask = np.zeros((mask.shape[0],mask.shape[1]))
     for bbox in labels[bbox_type]:
+        h = BBox.get_bbox_limits(np.array(bbox))
         mask_0 = empty_mask.copy()
         cv2.fillPoly(mask_0, [np.array(bbox,dtype=int)], 1)
-        coords = np.argwhere((mask_0 == 1) & (mask != 0)).T.tolist() # y,x
-        labels['masks'].append([coords[1],coords[0]]) # x,y
+        coords = np.argwhere((mask_0[h[2]:h[3], h[0]:h[1]] == 1) & (mask[h[2]:h[3], h[0]:h[1]] != 0)).T.tolist() # y,x
+        labels['masks'].append([coords[1] + h[0],coords[0] + h[2]]) # x,y
     return labels
 
 def get_xview_classes():


### PR DESCRIPTION
I made set_mask more time efficient by localizing the search area of np.argwhere according to the horizontal bounding boxes. Which led the time taken to achieve the same result to halve. 

I recorded the time with the time package (import time) and used the function time.time(). The oprations where executed on the DOTA dataset (train).

The results for the first 16 examples (time in seconds):

new: 6.176894187927246
old: 14.036651849746704

new: 0.7499403953552246
old: 1.4769632816314697

new: 4.177222728729248
old: 8.515252113342285

new: 0.19158291816711426
old: 0.4943399429321289

new: 0.10106587409973145
old: 0.2302532196044922

new: 0.7859718799591064
old: 2.2565560340881348

new: 0.2890481948852539
old: 0.763145923614502

new: 3.402623176574707
old: 6.619785308837891

new: 0.36213135719299316
old: 1.0220541954040527

new: 0.5472202301025391
old: 0.978334903717041

new: 7.634104013442993
old: 16.32474422454834

new: 1.0918629169464111
old: 1.6546440124511719

new: 14.10968828201294
old: 31.05443811416626

new: 1.3088610172271729
old: 2.5456385612487793

new: 1.5703225135803223
old: 3.1654348373413086

new: 2.8368587493896484
old: 5.51551628112793