### PR TITLE
Iou also uses hbboxes

### DIFF
--- a/satellitepy/evaluate/utils.py
+++ b/satellitepy/evaluate/utils.py
@@ -28,7 +28,7 @@ def match_gt_and_det_bboxes(gt_labels, det_labels):
     if gt_labels is None:
         return matches
 
-    if 'obboxes' in det_labels:
+    if 'obboxes' in det_labels and any(gt_labels['obboxes']):
         ious = get_ious(det_labels['obboxes'], gt_labels['obboxes'])
     else:
         ious = get_ious(det_labels['hbboxes'], gt_labels['hbboxes'])


### PR DESCRIPTION
Major bug: `satellitepy/evaluate/utils.py/match_gt_and_det_bboxes` used `obboxes` for IoU calculation if `obboxes` in detections, even if `obboxes` are missing in ground truth. This leads to an IoU of 0 for all datasets that don't have `obboxes` (XView, DIOR, Potsdam, VHR) if the model is trained with `obboxes`, which is always the case for us. 
This did not affect the training, but these datasets were completely ignored for testing/evaluation.