### PR TITLE
Option to keep empty patches in create_patches.

### DIFF
--- a/satellitepy/utils/path_utils.py
+++ b/satellitepy/utils/path_utils.py
@@ -66,7 +66,7 @@ def init_logger(config_path, log_path):
     logging.config.fileConfig(config_path, defaults={'logfilename': log_path})
 
 
-def create_folder(folder):
+def create_folder(folder, ask_permission=True):
     """
     Create the given folder
     Parameters
@@ -79,9 +79,10 @@ def create_folder(folder):
     True if folder is confirmed to be created or if it already exists. Else, False.
     """
     if not folder.exists():
-        msg = f'The following folder will be created:\n{folder}\nDo you confirm?[y/n] '
-        ans = input(msg)
-        if ans == 'y':
+        if ask_permission:
+            msg = f'The following folder will be created:\n{folder}\nDo you confirm?[y/n] '
+            ans = input(msg)
+        if not ask_permission or ans == 'y':
             Path(folder).mkdir(parents=True, exist_ok=True)
             return 1
         raise AssertionError('Please confirm it.\n')

--- a/tools/data/create_patches.py
+++ b/tools/data/create_patches.py
@@ -35,6 +35,7 @@ def get_args():
     parser.add_argument('--patch-overlap', type=int, help='Overlapping size of neighboring patches. In CNN '
                                                           'terminology, stride = patch-size - patch-overlap. '
                                                           'If necessary, the original image will be padded with zeros to create full size patches.')
+    parser.add_argument('--keep-empty', type=bool, default=False, help='Keeps empty patches if True. All black patches are still discarded. Default is False.')
     parser.add_argument('--log-config-path', default=None, type=Path, help='Log config file.')
     parser.add_argument('--log-path', type=Path, default=None, help='Log path.')
     # Reading image
@@ -90,6 +91,7 @@ def run(parser):
         image_read_module=args.image_read_module,
         rescaling=args.rescaling,
         interpolation_method=args.interpolation_method,
+        keep_empty=args.keep_empty
     )
 
 


### PR DESCRIPTION
Added the option to keep empty patches during patch creation. All black patches are still skipped. Just add --keep-empty flag

Also added the option **not** to ask permission for create_folder. E.g. for patch creation, 3 (nested) folders are created:
- `out-folder`
- `out-folder/images`
- `out-folder/labels`
I think it is enough to agree to creating `out-folder`, asking for the other two is unnecessary and annoying.
Asking for permission multiple times happens for most scripts we are using, I only changed it for create_patches. I can change it for other scripts when I encounter it if you agree.