### PR TITLE
Create folders for all classes containing chips with information such…

### DIFF
--- a/satellitepy/data/chip.py
+++ b/satellitepy/data/chip.py
@@ -1,15 +1,42 @@
 """
 Toolset for creating chips
 """
+import math
+
+import cv2
+import numpy
 import numpy as np
 from satellitepy.data.bbox import BBox
 from satellitepy.data.labels import init_satellitepy_label, get_all_satellitepy_keys, set_image_keys
 
 
-def create_chip(img, hbbox):
-    chip_img = img[hbbox[2]:hbbox[3], hbbox[0]:hbbox[1], :]
+def create_chip(img, bbox, margin=0, draw_corners=False):
+    center_x = np.mean(bbox[:, 0])
+    center_y = np.mean(bbox[:, 1])
+    angle = BBox(corners=bbox).get_orth_angle()
 
-    return chip_img
+    if draw_corners:
+        img = cv2.copyMakeBorder(img, 200, 200, 200, 200, cv2.BORDER_CONSTANT, value=0)
+        center_x += 200
+        center_y += 200
+        bbox += 200
+        for coords in bbox:
+            cv2.circle(img, (coords[0], coords[1]), 1, (0, 0, 255), 2)
+
+    center = (center_x, center_y)
+
+    M = cv2.getRotationMatrix2D(center, math.degrees(angle)-90, 1.0)
+    rotated = cv2.warpAffine(img, M, (img.shape[1], img.shape[0]))
+    width, height, _ = rotated.shape
+
+    rot_bbox = np.array(BBox(corners=bbox).rotate_corners(-angle), dtype=int)
+    rot_hbbox = BBox.get_bbox_limits(rot_bbox)
+
+    rot_hbbox = apply_margin(rot_hbbox, margin, height, width)
+
+    chip_img = rotated[rot_hbbox[2]:rot_hbbox[3], rot_hbbox[0]:rot_hbbox[1], :]
+
+    return chip_img, (int(center_x), int(center_y))
 
 
 def apply_margin(hbbox, margin_size, max_y, max_x):
@@ -21,48 +48,46 @@ def apply_margin(hbbox, margin_size, max_y, max_x):
     return np.array([x_0, x_1, y_0, y_1])
 
 
-def get_chips(img, gt_labels, margin_size=100):
-    height, width, channels = img.shape
-
+def get_chips(img, labels, task=None, margin_size=50):
     all_satellitepy_keys = get_all_satellitepy_keys()
 
     chips_dict = {
         'images': [],
-        'labels': init_satellitepy_label()
+        'labels': init_satellitepy_label(),
+        'attributes': {
+            'center': [],
+            'lengths': [],
+            'widths': [],
+            'task': []
+        }
     }
 
-    if [None] * len(gt_labels['obboxes']) == gt_labels['obboxes']:
-        bbox_type = "hbboxes"
-    else:
+    if any(labels['obboxes']):
         bbox_type = "obboxes"
+    else:
+        bbox_type = "hbboxes"
 
-    bboxes = gt_labels[bbox_type]
+    bboxes = labels[bbox_type]
 
     for i, bbox in enumerate(bboxes):
-        bbox = np.array(bbox).astype(int)
+        mbbox = np.array(bbox).astype(int)
 
-        if bbox_type == "obboxes":
-            hbbox = BBox.get_bbox_limits(bbox)
-        else:
-            hbbox = bbox
+        chip_img, center = create_chip(img, mbbox, margin_size, draw_corners=True)
 
-        hbbox = apply_margin(hbbox, margin_size, height, width)
+        set_image_keys(all_satellitepy_keys, chips_dict['labels'], labels, i)
 
-        chip_img = create_chip(img, hbbox)
-        chip_bbox = bbox - [hbbox[0], hbbox[2]]
+        if task:
+            chips_dict['attributes']['task'].append(labels[task][i])
 
-        set_image_keys(all_satellitepy_keys, chips_dict['labels'], gt_labels, i)
-
-        chips_dict['labels'][bbox_type][-1] = [chip_bbox.tolist()]
+        chips_dict['attributes']['center'].append(center)
+        params = BBox(corners=bbox).get_params()
+        o_length = params[3]
+        o_width = params[2]
+        chips_dict['attributes']['lengths'].append(o_length)
+        chips_dict['attributes']['widths'].append(o_width)
         chips_dict['images'].append(chip_img)
 
-        if gt_labels['masks'][i] != None:
-            chip_mask = np.array(gt_labels['masks'][i])
 
-            chip_mask[0] -= hbbox[0]
-            chip_mask[1] -= hbbox[2]
-
-            chips_dict['labels']['masks'][-1] = chip_mask.tolist()
 
     return chips_dict
 

--- a/satellitepy/utils/path_utils.py
+++ b/satellitepy/utils/path_utils.py
@@ -79,16 +79,13 @@ def create_folder(folder, ask_permission=True):
     True if folder is confirmed to be created or if it already exists. Else, False.
     """
     if not folder.exists():
-        msg = f'The following folder will be created:\n{folder}\nDo you confirm?[y/n] '
         if ask_permission:
+            msg = f'The following folder will be created:\n{folder}\nDo you confirm?[y/n] '
             ans = input(msg)
-            if ans == 'y':
-                Path(folder).mkdir(parents=True, exist_ok=True)
-                return 1
-            raise AssertionError('Please confirm it.\n')
-        else:
+        if not ask_permission or ans == 'y':
             Path(folder).mkdir(parents=True, exist_ok=True)
             return 1
+        raise AssertionError('Please confirm it.\n')
     else:
         return 1
 

--- a/satellitepy/utils/path_utils.py
+++ b/satellitepy/utils/path_utils.py
@@ -66,7 +66,7 @@ def init_logger(config_path, log_path):
     logging.config.fileConfig(config_path, defaults={'logfilename': log_path})
 
 
-def create_folder(folder):
+def create_folder(folder, ask_permission=True):
     """
     Create the given folder
     Parameters
@@ -80,11 +80,15 @@ def create_folder(folder):
     """
     if not folder.exists():
         msg = f'The following folder will be created:\n{folder}\nDo you confirm?[y/n] '
-        ans = input(msg)
-        if ans == 'y':
+        if ask_permission:
+            ans = input(msg)
+            if ans == 'y':
+                Path(folder).mkdir(parents=True, exist_ok=True)
+                return 1
+            raise AssertionError('Please confirm it.\n')
+        else:
             Path(folder).mkdir(parents=True, exist_ok=True)
             return 1
-        raise AssertionError('Please confirm it.\n')
     else:
         return 1
 

--- a/tools/data/create_class_chips.py
+++ b/tools/data/create_class_chips.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import configargparse
+
+from satellitepy.data.tools import save_class_chips
+from satellitepy.utils.path_utils import get_project_folder, init_logger, create_folder
+
+project_folder = get_project_folder()
+
+def get_args():
+    """Arguments parser."""
+
+    parser = configargparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--in-label-format', type=str, required=True,
+                        help='Label file format. e.g., dota, fair1m')
+    parser.add_argument('--in-image-folder', type=Path, required=True,
+                        help='Input folder which contains the images.')
+    parser.add_argument('--in-label-folder', type=Path, required=True,
+                        help='Input folder which contains the labels.')
+    parser.add_argument('--task', type=str, default='fine-class', help='Task by which the chips are sorted. Default is fine-class.')
+    parser.add_argument('--out-folder', type=Path, required=True,
+                        help='Save folder for chips. Images will be saved in <output-folder>/<class-name>/images.')
+    parser.add_argument('--log-config-path', default=project_folder /
+                        Path("configs/log.config"), type=Path, help='Log config file.')
+    parser.add_argument('--in-mask-folder', type=Path, required=False,
+                        help='Folder of original mask images. The mask images in this folder will be used to set mask '
+                             'pixel coordinates in out labels.')
+
+    args = parser.parse_args()
+    return args
+
+
+def run(args):
+    in_label_format = args.in_label_format
+    in_image_folder = Path(args.in_image_folder)
+    in_label_folder = Path(args.in_label_folder)
+
+    if args.in_mask_folder is not None:
+        in_mask_folder = Path(args.in_mask_folder)
+    else:
+        in_mask_folder = None
+
+    out_folder = Path(args.out_folder)
+    assert create_folder(out_folder)
+
+    task = args.task
+
+    log_path = Path(out_folder) / 'chip_creation.log'
+    init_logger(config_path=args.log_config_path, log_path=log_path)
+
+    save_class_chips(
+        label_format=in_label_format,
+        image_folder=in_image_folder,
+        label_folder=in_label_folder,
+        out_folder=out_folder,
+        task=task,
+        mask_folder=in_mask_folder
+    )
+
+
+if __name__ == '__main__':
+    args = get_args()
+    run(args)


### PR DESCRIPTION
Tool for checking annotations. For each class in the data, a folder is created. Each folder contains chips that are rotated upwards alongside additional information such as width and height of the object/plane and the class averages for comparison.
Red dots mark the corners of the bounding boxes so that the airplane is not obstructed.

The idea of this is to check the annotations focusing on one class at a time, making it easier to find planes that don't fit in.
![image](https://github.com/Iammuratc/satellitepy/assets/98040394/cc750830-9182-45c1-8867-ccb7d29f40fd)

Still needs to be checked on the original FineAir images, I used patches.