### PR TITLE
Fix/move matching to eval

### DIFF
--- a/satellitepy/data/utils.py
+++ b/satellitepy/data/utils.py
@@ -316,11 +316,11 @@ def get_satellitepy_table():
         },
         'fine-class':
         {
-            'A220'       	                :	0	,	   # Fair1m
-            'A321'       	                :	1	,	   # Fair1m
-            'A330'       	                :	2	,	   # Fair1m
+             'A220'       	                :	0	,	   # Fair1m FR24
+            'A321'       	                :	1	,	   # Fair1m FR24
+            'A330'       	                :	2	,	   # Fair1m FR24
             'Airbus_A330'               	:	2	,	   # Rareplanes_synthetic
-            'A350'                      	:	3	,	   # Fair1m
+            'A350'                      	:	3	,	   # Fair1m FR24
             'Airbus_A320'               	:	4	,	   # Rareplanes_synthetic
             'ARJ21'      	                :	5	,	   # Fair1m
             'Motorboat'                 	:	6	,	   # ShipNet
@@ -404,7 +404,7 @@ def get_satellitepy_table():
             'Bombardier_Challenger'     	:	79	,	   # Rareplanes_synthetic
             'Bombardier_CRJ'            	:	80	,	   # Rareplanes_synthetic
             'Bombardier_Learjet'        	:	81	,	   # Rareplanes_synthetic
-            'Cessna'                    	:	82	,	   # Rareplanes_synthetic
+            'Cessna'                    	:	82	,	   # Rareplanes_synthetic FR24
             'Cessna_170'                	:	83	,	   # Rareplanes_synthetic
             'Cessna_172'                	:	84	,	   # Rareplanes_synthetic
             'Cessna_310'                	:	85	,	   # Rareplanes_synthetic
@@ -430,6 +430,46 @@ def get_satellitepy_table():
             'Car'                           :   105,      # Vedai
             'Camping Car'                   :   106,      # Vedai
             'Motorcycle'                    :   107,      # Vedai
+            'B787'                          :   14,      # FR24
+            'A320'                          :   4,      # FR24
+            'E190'                          :   110,      # FR24
+            'E195'                          :   111,      # FR24
+            'B777'                          :   13,      # FR24
+            'B737'                          :   11,      # FR24
+            'E175'                          :   114,      # FR24
+            'B747'                          :   12,      # FR24
+            'A319'                          :   66,      # FR24
+            'B767'                          :   76,      # FR24
+            'A380'                          :   69,      # FR24
+            'B757'                          :   75,      # FR24
+            'E170'                          :   115,      # FR24
+            'CRJ7'                          :   116,      # FR24
+            'E145'                          :   117,      # FR24
+            'CRJ2'                          :   118,      # FR24
+            'MD11'                          :   119,      # FR24
+            'B717'                          :   73,      # FR24
+            'A340'                          :   120,      # FR24
+            'CRJ9'                          :   121,      # FR24
+            'CRJ-900'                       :   122,      # FR24
+            'CRJ-701'                       :   123,      # FR24
+            'CRJ-700'                       :   124,      # FR24
+            'R175'                          :   125,      # FR24
+            'Beechcraft'                    :   126,      # FR24
+            'ERJ'                           :   127,      # FR24
+            'CRJ'                           :   128,      # FR24
+            'Falcon'                        :   129,      # FR24
+            'Sukhoi-100'                    :   130,      # FR24
+            'Embraer'                       :   131,      # FR24
+            'Bombardier-Global'             :   132,      # FR24
+            'E135'                          :   133,      # FR24
+            'Cessna560'                     :   134,      # FR24
+            'H25B'                          :   135,      # FR24
+            'Cessna-Citation'               :    86,      # FR24
+            'Gulfstream'                    :   136,      # FR24
+            'Gulfstream-Global'             :   137,      # FR24
+            'Embraer-Praetor'               :   138,      # FR24
+            'Embraer-Phenom'                :   139,      # FR24
+            'DeHavilland-Dash-8'            :   140,      # FR24
         },
         'very-fine-class':{
 			'Airbus_A330-300'					: 0,	# Rareplanes_synthetic

--- a/satellitepy/data/utils.py
+++ b/satellitepy/data/utils.py
@@ -316,18 +316,18 @@ def get_satellitepy_table():
         },
         'fine-class':
         {
-            'A220'       	                :	0	,	   # Fair1m FR24
-            'A321'       	                :	1	,	   # Fair1m FR24
-            'A330'       	                :	2	,	   # Fair1m FR24
+            'A220'       	                :	0	,	   # Fair1m
+            'A321'       	                :	1	,	   # Fair1m
+            'A330'       	                :	2	,	   # Fair1m
             'Airbus_A330'               	:	2	,	   # Rareplanes_synthetic
-            'A350'                      	:	3	,	   # Fair1m FR24
+            'A350'                      	:	3	,	   # Fair1m
             'Airbus_A320'               	:	4	,	   # Rareplanes_synthetic
             'ARJ21'      	                :	5	,	   # Fair1m
             'Motorboat'                 	:	6	,	   # ShipNet
             'Hovercraft'                	:	7	,	   # ShipNet
             'Patrol'                    	:	8	,	   # ShipNet
             'Destroyer'                 	:	9	,	   # ShipNet
-            'Commander'                 	:	10	,	   # ShipNet		
+            'Commander'                 	:	10	,	   # ShipNet
             'Boeing_737'    	            :	11	,	   # Rareplanes_synthetic
             'Boeing737'     	            :	11	,	   # Fair1m
             'Boeing_747'    	            :	12	,	   # Rareplanes_synthetic
@@ -341,34 +341,34 @@ def get_satellitepy_table():
             'Cargo Plane'    	            :	18	,	   # Xview
             'Truck'      	                :	19	,	   # Xview, Vedai
             'Cement Mixer'    	            :	20	,	   # Xview
-            'Landing'                   	:	21	,	   # ShipNet		
+            'Landing'                   	:	21	,	   # ShipNet
             'Maritime Vessel'   	        :	22	,	   # Xview
             'Crane Truck'    	            :	23	,	   # Xview
             'Dry Cargo Ship'            	:	24	,	   # Fair1m
             'Dump Truck'    	            :	25	,	   # Fair1m	 Xview
             'Engineering Ship'          	:	26	,	   # Fair1m
             'Engineering Vessel'        	:	26	,	   # Xview
-            'Cruiser'                   	:	27	,	   # ShipNet		
-            'Frigate'                   	:	28	,	   # ShipNet		
-            'Fishing Vessel'            	:	29	,	   # ShipNet	 Xview	
+            'Cruiser'                   	:	27	,	   # ShipNet
+            'Frigate'                   	:	28	,	   # ShipNet
+            'Fishing Vessel'            	:	29	,	   # ShipNet	 Xview
             'Fishing Boat'              	:	29	,	   # Fair1m
-            'Auxiliary Ship'            	:	30	,	   # ShipNet		
+            'Auxiliary Ship'            	:	30	,	   # ShipNet
             'Flat Car'                  	:	31	,	   # Xview
             'Front Loader'    	            :	32	,	   # Xview
             'Ground Grader'             	:	33	,	   # Xview
-            'Barge'                     	:	34	,	   # ShipNet		
+            'Barge'                     	:	34	,	   # ShipNet
             'Haul Truck'    	            :	35	,	   # Xview
-            'Aircraft Carrier'          	:	36	,	   # ShipNet		
-            'Yacht'                     	:	37	,	   # ShipNet	 Xview	
+            'Aircraft Carrier'          	:	36	,	   # ShipNet
+            'Yacht'                     	:	37	,	   # ShipNet	 Xview
             'Tugboat'                   	:	38	,	   # ShipNet	 Fair1m	 Xview
-            'Cargo'                     	:	39	,	   # ShipNet		
+            'Cargo'                     	:	39	,	   # ShipNet
             'Liquid Cargo Ship'   	        :	40	,	   # Fair1m
             'Locomotive'    	            :	41	,	   # Xview
-            'Container Ship'            	:	42	,	   # ShipNet	 Xview	
-            'Oil Tanker'                	:	43	,	   # ShipNet	 Xview	
-            'Mobile Crane'              	:	44	,	   # Xview		
-            'RoRo'                      	:	45	,	   # ShipNet		
-            'Sailboat'                  	:	46	,	   # ShipNet	Xview	
+            'Container Ship'            	:	42	,	   # ShipNet	 Xview
+            'Oil Tanker'                	:	43	,	   # ShipNet	 Xview
+            'Mobile Crane'              	:	44	,	   # Xview
+            'RoRo'                      	:	45	,	   # ShipNet
+            'Sailboat'                  	:	46	,	   # ShipNet	Xview
             'Cargo Truck'    	            :	47	,	   # Fair1m	 Xview
             'Passenger Car'             	:	48	,	   # Xview
             'Small Car'     	            :	49	,	   # Fair1m	 Xview
@@ -388,8 +388,8 @@ def get_satellitepy_table():
             'Utility Truck'             	:	63	,	   # Xview
             'Van'      	                    :	64	,	   # Fair1m	Vedai
             'Trailer'                   	:	65	,	   # Fair1m
-            'Airbus_A-319'              	:	66	,	   # Rareplanes_synthetic		
-            'Airbus_A300'               	:	67	,	   # Rareplanes_synthetic		
+            'Airbus_A-319'              	:	66	,	   # Rareplanes_synthetic
+            'Airbus_A300'               	:	67	,	   # Rareplanes_synthetic
             'Airbus_A'                  	:	68	,	   # Rareplanes_synthetic
             'Airbus_A380'               	:	69	,	   # Rareplanes_synthetic
             'ATR_ATR'                   	:	70	,	   # Rareplanes_synthetic
@@ -404,7 +404,7 @@ def get_satellitepy_table():
             'Bombardier_Challenger'     	:	79	,	   # Rareplanes_synthetic
             'Bombardier_CRJ'            	:	80	,	   # Rareplanes_synthetic
             'Bombardier_Learjet'        	:	81	,	   # Rareplanes_synthetic
-            'Cessna'                    	:	82	,	   # Rareplanes_synthetic FR24
+            'Cessna'                    	:	82	,	   # Rareplanes_synthetic
             'Cessna_170'                	:	83	,	   # Rareplanes_synthetic
             'Cessna_172'                	:	84	,	   # Rareplanes_synthetic
             'Cessna_310'                	:	85	,	   # Rareplanes_synthetic
@@ -425,51 +425,11 @@ def get_satellitepy_table():
             'SudAviation_Caravelle'     	:	100	,	   # Rareplanes_synthetic
             'Tupolev_154'               	:	101	,	   # Rareplanes_synthetic
             'Ferry'                     	:	102	,	  # ShipNet	 Xview
-            'Submarine'                 	:	103	,	  # ShipNet		
-            'Excavator'                 	:	104	,	  # Xview		
+            'Submarine'                 	:	103	,	  # ShipNet
+            'Excavator'                 	:	104	,	  # Xview
             'Car'                           :   105,      # Vedai
             'Camping Car'                   :   106,      # Vedai
             'Motorcycle'                    :   107,      # Vedai
-            'B787'                          :   14,      # FR24
-            'A320'                          :   4,      # FR24
-            'E190'                          :   110,      # FR24
-            'E195'                          :   111,      # FR24
-            'B777'                          :   13,      # FR24
-            'B737'                          :   11,      # FR24
-            'E175'                          :   114,      # FR24
-            'B747'                          :   12,      # FR24
-            'A319'                          :   66,      # FR24
-            'B767'                          :   76,      # FR24
-            'A380'                          :   69,      # FR24
-            'B757'                          :   75,      # FR24
-            'E170'                          :   115,      # FR24
-            'CRJ7'                          :   116,      # FR24
-            'E145'                          :   117,      # FR24
-            'CRJ2'                          :   118,      # FR24
-            'MD11'                          :   119,      # FR24
-            'B717'                          :   73,      # FR24
-            'A340'                          :   120,      # FR24
-            'CRJ9'                          :   121,      # FR24
-            'CRJ-900'                       :   122,      # FR24
-            'CRJ-701'                       :   123,      # FR24
-            'CRJ-700'                       :   124,      # FR24
-            'R175'                          :   125,      # FR24
-            'Beechcraft'                    :   126,      # FR24
-            'ERJ'                           :   127,      # FR24
-            'CRJ'                           :   128,      # FR24
-            'Falcon'                        :   129,      # FR24
-            'Sukhoi-100'                    :   130,      # FR24
-            'Embraer'                       :   131,      # FR24
-            'Bombardier-Global'             :   132,      # FR24
-            'E135'                          :   133,      # FR24
-            'Cessna560'                     :   134,      # FR24
-            'H25B'                          :   135,      # FR24
-            'Cessna-Citation'               :    86,      # FR24
-            'Gulfstream'                    :   136,      # FR24  
-            'Gulfstream-Global'             :   137,      # FR24
-            'Embraer-Praetor'               :   138,      # FR24
-            'Embraer-Phenom'                :   139,      # FR24
-            'DeHavilland-Dash-8'            :   140,      # FR24
         },
         'very-fine-class':{
 			'Airbus_A330-300'					: 0,	# Rareplanes_synthetic

--- a/satellitepy/evaluate/bbavector/tools.py
+++ b/satellitepy/evaluate/bbavector/tools.py
@@ -108,9 +108,7 @@ def save_patch_results(
 
         if in_label_folder:
             gt_labels = read_label(data_dict['label_path'][0], in_label_format)
-            matches = match_gt_and_det_bboxes(gt_labels, save_dict)
             save_dict['gt_labels'] = gt_labels
-            save_dict['matches'] = matches
 
         if 'masks' in tasks:
             mask = save_dict['masks']
@@ -224,12 +222,9 @@ def save_original_image_results(
 
         merged_det_labels, mask = merge_patch_results(patch_dict, patch_size, img.shape)
 
-        # matches = match_gt_and_det_bboxes(gt_labels, merged_det_labels)
-
         result = {
             'gt_labels': gt_labels,
-            'det_labels': merged_det_labels,
-            # 'matches': matches
+            'det_labels': merged_det_labels
         }
 
         json_path = Path(result_folder) / f'{img_name}.json'

--- a/satellitepy/evaluate/bbavector/tools.py
+++ b/satellitepy/evaluate/bbavector/tools.py
@@ -224,12 +224,12 @@ def save_original_image_results(
 
         merged_det_labels, mask = merge_patch_results(patch_dict, patch_size, img.shape)
 
-        matches = match_gt_and_det_bboxes(gt_labels, merged_det_labels)
+        # matches = match_gt_and_det_bboxes(gt_labels, merged_det_labels)
 
         result = {
             'gt_labels': gt_labels,
             'det_labels': merged_det_labels,
-            'matches': matches
+            # 'matches': matches
         }
 
         json_path = Path(result_folder) / f'{img_name}.json'

--- a/satellitepy/evaluate/utils.py
+++ b/satellitepy/evaluate/utils.py
@@ -71,6 +71,8 @@ def set_conf_mat_from_result(
     det_inds = np.argmax(det_results[task], axis=1) if len(det_results[task]) > 0 else []
     conf_scores = np.max(det_results[task], axis=1) if len(det_inds) > 0 else []
 
+    matches = match_gt_and_det_bboxes(result['gt_labels'], det_results)
+
     if len(task_result) == 0:
         return conf_mat, ignored_instances_ret, ignored_cnt
     for i_iou_th, iou_th in enumerate(iou_thresholds):
@@ -81,11 +83,11 @@ def set_conf_mat_from_result(
                 if conf_score < conf_score_th:
                     continue
 
-                iou_score = result['matches']['iou']['scores'][i_conf_score]
+                iou_score = matches['iou']['scores'][i_conf_score]
                 if iou_score < iou_th:
                     continue
 
-                gt_index = result['matches']['iou']['indexes'][i_conf_score]
+                gt_index = matches['iou']['indexes'][i_conf_score]
 
                 det_gt_instance_name = task_result[gt_index]
 


### PR DESCRIPTION
Moved matching of gt and detections from test script to evaluation scripts. This allows performing nms before matching, resulting in faster evaluation